### PR TITLE
Genres thunks

### DIFF
--- a/src/Hooks/useFetchGenres.ts
+++ b/src/Hooks/useFetchGenres.ts
@@ -1,9 +1,7 @@
 /** @format */
 
-import { fetchGenresFailure, fetchGenresStart, fetchGenresSucess } from '@/Redux/Slices/genresSlice';
+import { genresThunks } from '@/Redux/Slices/Thunks/genresThunks';
 import { AppDispatch, RootState } from '@/Redux/store';
-import { fetchGenres } from '@/services/services';
-import axios from 'axios';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -14,25 +12,7 @@ export const useFetchGenres = () => {
 
   useEffect(() => {
     const controller = new AbortController();
-    const signal = controller.signal;
-
-    const genresList = async () => {
-      try {
-        dispatch(fetchGenresStart());
-        const response = await fetchGenres(signal);
-        dispatch(fetchGenresSucess(response));
-      } catch (error) {
-        if (axios.isCancel(error)) {
-          console.log('Request was cancelled');
-          return;
-        }
-
-        dispatch(fetchGenresFailure((error as Error).message));
-      }
-    };
-
-    genresList();
-
+    dispatch(genresThunks());
     return () => {
       controller.abort();
     };

--- a/src/Redux/Slices/Thunks/genresThunks.ts
+++ b/src/Redux/Slices/Thunks/genresThunks.ts
@@ -1,0 +1,25 @@
+/** @format */
+
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { GENRES } from '../genresSlice';
+import { fetchGenres } from '@/services/services';
+import { isAxiosError } from 'axios';
+
+export const genresThunks = createAsyncThunk<GENRES, void, { rejectValue: string }>(
+  'genres/fetchGenres',
+  async (_, thunkApi) => {
+    try {
+      const response = await fetchGenres(thunkApi.signal);
+      return response;
+    } catch (error) {
+      let errorMessage = 'Failed to fetch Genres';
+
+      if (isAxiosError(error)) {
+        errorMessage = error.response?.data?.message || error.message;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      return thunkApi.rejectWithValue(errorMessage);
+    }
+  },
+);

--- a/src/Redux/Slices/genresSlice.ts
+++ b/src/Redux/Slices/genresSlice.ts
@@ -1,6 +1,7 @@
 /** @format */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { genresThunks } from './Thunks/genresThunks';
 
 interface GENRE_RESULTS {
   id: number;
@@ -10,7 +11,7 @@ interface GENRE_RESULTS {
   image_background: string;
 }
 
-interface GENRES {
+export interface GENRES {
   count: number;
   next: string;
   previous: string;
@@ -35,20 +36,6 @@ const genresSlice = createSlice({
   name: 'genres',
   initialState,
   reducers: {
-    fetchGenresStart: (state) => {
-      state.isLoading = true;
-      state.error = null;
-    },
-
-    fetchGenresSucess: (state, action: PayloadAction<GENRES>) => {
-      state.isLoading = false;
-      state.genres = action.payload;
-    },
-
-    fetchGenresFailure: (state, action: PayloadAction<string>) => {
-      state.isLoading = false;
-      state.error = action.payload;
-    },
     setGenresName: (state, action: PayloadAction<string>) => {
       state.genresName = action.payload;
     },
@@ -56,9 +43,27 @@ const genresSlice = createSlice({
       state.genresName = null;
     },
   },
+  extraReducers: (builder) => {
+    // Fetch Genres start
+    builder.addCase(genresThunks.pending, (state) => {
+      state.isLoading = true;
+      state.error = null;
+    });
+
+    // Fetch Genres Success
+    builder.addCase(genresThunks.fulfilled, (state, action) => {
+      state.isLoading = false;
+      state.genres = action.payload;
+    });
+
+    // Fetch Genres Fail
+    builder.addCase(genresThunks.rejected, (state, action) => {
+      state.isLoading = false;
+      state.error = action.payload ?? null;
+    });
+  },
 });
 
-export const { fetchGenresStart, fetchGenresSucess, fetchGenresFailure, setGenresName, clearGenresName } =
-  genresSlice.actions;
+export const { setGenresName, clearGenresName } = genresSlice.actions;
 
 export const genresReducer = genresSlice.reducer;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -18,7 +18,7 @@ export const searchGames = async (searchInput: string | null, signal?: AbortSign
   const response = await axios.get(`${baseUrl}/games?key=${API_KEY}&page=2&page_size=20&search=${searchInput}`, {
     signal,
   });
-  console.log(response.data);
+
   return response.data;
 };
 
@@ -38,14 +38,9 @@ export const getCroppedImageUrl = (url: string) => {
 };
 
 export const fetchGenres = async (signal?: AbortSignal) => {
-  try {
-    const response = await axios.get(`${baseUrl}/genres?key=${API_KEY}`, { signal });
-    const data = response.data;
-    return data;
-  } catch (error) {
-    console.log(`Error fetching genres:`, error);
-    throw error;
-  }
+  const response = await axios.get(`${baseUrl}/genres?key=${API_KEY}`, { signal });
+  const data = response.data;
+  return data;
 };
 
 export const fetchPlatforms = (signal?: AbortSignal) => {


### PR DESCRIPTION
### What I did:
- Refactored genre filtering logic using Redux Thunks
- Removed manual dispatching of isLoading, genres, and error states
- Updated the Redux slice to handle async logic via extraReducers

### why ? 
Previously, we manually dispatched multiple actions to manage isLoading, genres, and error during the API call.
Now, using a thunk simplifies this by handling all async logic in one place, improving readability and maintainability.

### Test:
- Select a genre → Filtered games should display
- Heading updates to the selected genre name
- isLoading spinner works correctly during fetch
- Error state is handled gracefully if API fails

